### PR TITLE
Fix typos and other cleanup

### DIFF
--- a/Lidgren.Network/NetBigInteger.cs
+++ b/Lidgren.Network/NetBigInteger.cs
@@ -1157,7 +1157,7 @@ namespace Lidgren.Network
 					{
 						// Montgomery square algo doesn't exist, and a normal
 						// square followed by a Montgomery reduction proved to
-						// be almost as heavy as a Montgomery mulitply.
+						// be almost as heavy as a Montgomery multiply.
 						MultiplyMonty(yAccum, yVal, yVal, m.m_magnitude, mQ);
 					}
 					else

--- a/Lidgren.Network/NetBuffer.Read.cs
+++ b/Lidgren.Network/NetBuffer.Read.cs
@@ -17,7 +17,7 @@ namespace Lidgren.Network
 	public partial class NetBuffer
 	{
 		private const string c_readOverflowError = "Trying to read past the buffer size - likely caused by mismatching Write/Reads, different size or order.";
-		private const int c_bufferSize = 64; // Min 8 to hold anything but strings. Increase it if readed strings usally don't fit inside the buffer
+		private const int c_bufferSize = 64; // Min 8 to hold anything but strings. Increase it if read strings usually don't fit inside the buffer
 		private static object s_buffer;
 
 		/// <summary>

--- a/Lidgren.Network/NetConnection.MTU.cs
+++ b/Lidgren.Network/NetConnection.MTU.cs
@@ -74,7 +74,7 @@ namespace Lidgren.Network
 		{
 			int tryMTU;
 
-			// we've nevered encountered failure
+			// we've never encountered failure
 			if (m_smallestFailedMTU == -1)
 			{
 				// we've never encountered failure; expand by 25% each time

--- a/Lidgren.Network/NetConnection.cs
+++ b/Lidgren.Network/NetConnection.cs
@@ -380,7 +380,7 @@ namespace Lidgren.Network
 				int channelSlot = (int)method - 1 + sequenceChannel;
 				if (m_sendChannels[channelSlot] != null)
 				{
-					// we were pre-empted by another call to this method
+					// we were preempted by another call to this method
 					chan = m_sendChannels[channelSlot];
 				}
 				else
@@ -468,7 +468,7 @@ namespace Lidgren.Network
 				case NetMessageType.ExpandMTUSuccess:
 					if (m_peer.Configuration.AutoExpandMTU == false)
 					{
-						m_peer.LogDebug("Received ExpandMTURequest altho AutoExpandMTU is turned off!");
+						m_peer.LogDebug("Received ExpandMTURequest although AutoExpandMTU is turned off!");
 						break;
 					}
 					NetIncomingMessage emsg = m_peer.SetupReadHelperMessage(ptr, payloadLength);

--- a/Lidgren.Network/NetPeer.LatencySimulation.cs
+++ b/Lidgren.Network/NetPeer.LatencySimulation.cs
@@ -132,8 +132,8 @@ namespace Lidgren.Network
 			catch { }
 		}
 
-        //Avoids allocation on mapping to IPv6
-        private IPEndPoint targetCopy = new IPEndPoint(IPAddress.Any, 0);
+		//Avoids allocation on mapping to IPv6
+		private IPEndPoint targetCopy = new IPEndPoint(IPAddress.Any, 0);
 
 		internal bool ActuallySendPacket(byte[] data, int numBytes, NetEndPoint target, out bool connectionReset)
 		{
@@ -143,25 +143,25 @@ namespace Lidgren.Network
 			{
 				ba = NetUtility.GetCachedBroadcastAddress();
 
-                // TODO: refactor this check outta here
-                if (target.Address.Equals(ba))
-                {
-                    // Some networks do not allow 
-                    // a global broadcast so we use the BroadcastAddress from the configuration
-                    // this can be resolved to a local broadcast addresss e.g 192.168.x.255                    
-                    targetCopy.Address = m_configuration.BroadcastAddress;
-                    targetCopy.Port = target.Port;
-                    m_socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, true);
-                }
-                else if(m_configuration.DualStack && m_configuration.LocalAddress.AddressFamily == AddressFamily.InterNetworkV6)
-                    NetUtility.CopyEndpoint(target, targetCopy); //Maps to IPv6 for Dual Mode
-                else
-                {
-	                targetCopy.Port = target.Port;
-	                targetCopy.Address = target.Address;
-                }
+				// TODO: refactor this check outta here
+				if (target.Address.Equals(ba))
+				{
+					// Some networks do not allow
+					// a global broadcast so we use the BroadcastAddress from the configuration
+					// this can be resolved to a local broadcast address e.g 192.168.x.255
+					targetCopy.Address = m_configuration.BroadcastAddress;
+					targetCopy.Port = target.Port;
+					m_socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, true);
+				}
+				else if(m_configuration.DualStack && m_configuration.LocalAddress.AddressFamily == AddressFamily.InterNetworkV6)
+					NetUtility.CopyEndpoint(target, targetCopy); //Maps to IPv6 for Dual Mode
+				else
+				{
+					targetCopy.Port = target.Port;
+					targetCopy.Address = target.Address;
+				}
 
-                int bytesSent = m_socket.SendTo(data, 0, numBytes, SocketFlags.None, targetCopy);
+				int bytesSent = m_socket.SendTo(data, 0, numBytes, SocketFlags.None, targetCopy);
 				if (numBytes != bytesSent)
 					LogWarning("Failed to send the full " + numBytes + "; only " + bytesSent + " bytes sent in packet!");
 

--- a/Lidgren.Network/NetPeer.MessagePools.cs
+++ b/Lidgren.Network/NetPeer.MessagePools.cs
@@ -172,7 +172,7 @@ namespace Lidgren.Network
 			if (m_incomingMessagesPool == null || msg == null)
 				return;
 
-			NetException.Assert(m_incomingMessagesPool.Contains(msg) == false, "Recyling already recycled incoming message! Thread race?");
+			NetException.Assert(m_incomingMessagesPool.Contains(msg) == false, "Recycling already recycled incoming message! Thread race?");
 
 			byte[] storage = msg.m_data;
 			msg.m_data = null;
@@ -199,7 +199,7 @@ namespace Lidgren.Network
 			if (m_outgoingMessagesPool == null)
 				return;
 #if DEBUG
-			NetException.Assert(m_outgoingMessagesPool.Contains(msg) == false, "Recyling already recycled outgoing message! Thread race?");
+			NetException.Assert(m_outgoingMessagesPool.Contains(msg) == false, "Recycling already recycled outgoing message! Thread race?");
 			if (msg.m_recyclingCount != 0)
 				LogWarning("Wrong recycling count! should be zero; found " + msg.m_recyclingCount);
 #endif

--- a/Lidgren.Network/NetPeer.cs
+++ b/Lidgren.Network/NetPeer.cs
@@ -105,7 +105,7 @@ namespace Lidgren.Network
 		}
 
 		/// <summary>
-		/// Gets the configuration used to instanciate this NetPeer
+		/// Gets the configuration used to instantiate this NetPeer
 		/// </summary>
 		public NetPeerConfiguration Configuration { get { return m_configuration; } }
 

--- a/Lidgren.Network/NetPeerConfiguration.cs
+++ b/Lidgren.Network/NetPeerConfiguration.cs
@@ -307,7 +307,7 @@ namespace Lidgren.Network
 		}
 
 		/// <summary>
-		/// Enables or disables automatic flushing of the send queue. If disabled, you must manully call NetPeer.FlushSendQueue() to flush sent messages to network.
+		/// Enables or disables automatic flushing of the send queue. If disabled, you must manually call NetPeer.FlushSendQueue() to flush sent messages to network.
 		/// </summary>
 		public bool AutoFlushSendQueue
 		{

--- a/Lidgren.Network/NetReliableSenderChannel.cs
+++ b/Lidgren.Network/NetReliableSenderChannel.cs
@@ -61,13 +61,13 @@ namespace Lidgren.Network
 		internal override NetSendResult Enqueue(NetOutgoingMessage message)
 		{
 			m_queuedSends.Enqueue(message);
-			m_connection.m_peer.m_needFlushSendQueue = true; // a race condition to this variable will simply result in a single superflous call to FlushSendQueue()
+			m_connection.m_peer.m_needFlushSendQueue = true; // a race condition to this variable will simply result in a single superfluous call to FlushSendQueue()
 			if (m_queuedSends.Count <= GetAllowedSends())
 				return NetSendResult.Sent;
 			return NetSendResult.Queued;
 		}
 
-		// call this regularely
+		// call this regularly
 		internal override void SendQueuedMessages(double now)
 		{
 			//

--- a/Lidgren.Network/NetUnreliableSenderChannel.cs
+++ b/Lidgren.Network/NetUnreliableSenderChannel.cs
@@ -60,11 +60,11 @@ namespace Lidgren.Network
 			}
 
 			m_queuedSends.Enqueue(message);
-			m_connection.m_peer.m_needFlushSendQueue = true; // a race condition to this variable will simply result in a single superflous call to FlushSendQueue()
+			m_connection.m_peer.m_needFlushSendQueue = true; // a race condition to this variable will simply result in a single superfluous call to FlushSendQueue()
 			return NetSendResult.Sent;
 		}
 
-		// call this regularely
+		// call this regularly
 		internal override void SendQueuedMessages(double now)
 		{
 			int num = GetAllowedSends();

--- a/Lidgren.Network/Platform/PlatformWin32.cs
+++ b/Lidgren.Network/Platform/PlatformWin32.cs
@@ -1,4 +1,4 @@
-﻿#if !__ANDROID__ && !__CONSTRAINED__ && !WINDOWS_RUNTIME && !UNITY_STANDALONE_LINUX
+#if !__ANDROID__ && !__CONSTRAINED__ && !WINDOWS_RUNTIME && !UNITY_STANDALONE_LINUX
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -105,16 +105,16 @@ namespace Lidgren.Network
 				if (unicastAddress != null && unicastAddress.Address != null && unicastAddress.Address.AddressFamily == AddressFamily.InterNetwork)
 				{
 					var mask = unicastAddress.IPv4Mask;
-					byte[] ipAdressBytes = unicastAddress.Address.GetAddressBytes();
+					byte[] ipAddressBytes = unicastAddress.Address.GetAddressBytes();
 					byte[] subnetMaskBytes = mask.GetAddressBytes();
 
-					if (ipAdressBytes.Length != subnetMaskBytes.Length)
+					if (ipAddressBytes.Length != subnetMaskBytes.Length)
 						throw new ArgumentException("Lengths of IP address and subnet mask do not match.");
 
-					byte[] broadcastAddress = new byte[ipAdressBytes.Length];
+					byte[] broadcastAddress = new byte[ipAddressBytes.Length];
 					for (int i = 0; i < broadcastAddress.Length; i++)
 					{
-						broadcastAddress[i] = (byte)(ipAdressBytes[i] | (subnetMaskBytes[i] ^ 255));
+						broadcastAddress[i] = (byte)(ipAddressBytes[i] | (subnetMaskBytes[i] ^ 255));
 					}
 					return new IPAddress(broadcastAddress);
 				}


### PR DESCRIPTION
Inconsistent indentation and possibly wrong line break format fixed in one class.

Also removes `UTF-8 BOM` in one file.
